### PR TITLE
Run tests with CI

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,8 +9,8 @@ on:
 name: Run Tests on ECS
 
 jobs:
-  start_ecs_task:
-    name: Start ECS Task
+  run_ecs_tasks:
+    name: Run ECS Task
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -27,4 +27,8 @@ jobs:
     - name: Run smoke tests
       if: contains('smoke', github.event.inputs.tests)
       run: |
-        aws ecs run-task --cluster "ceramic-dev-tests" --task-definition "ceramic-dev-tests-smoke_tests"
+        aws ecs run-task \
+          --cluster ceramic-dev-tests \
+          --task-definition ceramic-dev-tests-smoke_tests \
+          --launch-type FARGATE \
+          --network-configuration ${{ secrets.NETWORK_CONFIGURATION }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -4,7 +4,7 @@ on:
       tests:
         description: "Comma separated list of test to run"
         required: false
-        default: '[smoke]'
+        default: ["smoke"]
 
 name: Run Tests on ECS
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -2,9 +2,9 @@ on:
   workflow_dispatch:
     inputs:
       tests:
-        description: "Comma separated list of test to run"
+        description: "Space separated list of tests to run. Runs all available by default."
         required: false
-        default: ["smoke"]
+        default: 'smoke'
 
 name: Run Tests on ECS
 
@@ -12,9 +12,6 @@ jobs:
   start_ecs_task:
     name: Start ECS Task
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        test_type: ${{ github.event.inputs }}
 
     steps:
     - name: Checkout
@@ -27,6 +24,7 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-east-2
 
-    - name: Run ${{ matrix.test_type }} tests
+    - name: Run smoke tests
+      if: contains('smoke', github.event.inputs.tests)
       run: |
-        aws ecs run-task --cluster "ceramic-dev-tests" --task-definition "ceramic-dev-tests-${{ matrix.test_type }}_tests"
+        aws ecs run-task --cluster "ceramic-dev-tests" --task-definition "ceramic-dev-tests-smoke_tests"

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -1,5 +1,2 @@
 #!/bin/sh
-npm run test:ci > /dev/null
-curl -X POST \
-  -H "Content-Type: application/json" \
-  -d @discord_results-summary.json $DISCORD_WEBHOOK_URL
+npm run test:ci

--- a/ci/jest-reporter.js
+++ b/ci/jest-reporter.js
@@ -1,7 +1,6 @@
-const child_process = require('child_process')
-const fs = require('fs')
-const { uniqueNamesGenerator, adjectives, animals, colors } = require('unique-names-generator')
 const { BaseReporter } = require('@jest/reporters')
+const child_process = require('child_process')
+const { uniqueNamesGenerator, adjectives, animals, colors } = require('unique-names-generator')
 
 class MyCustomReporter extends BaseReporter {
   constructor(globalConfig, options) {
@@ -28,16 +27,15 @@ class MyCustomReporter extends BaseReporter {
 
   onRunComplete(contexts, results) {
     const message = buildDiscordSummary(results, this.runId)
-    const summary = { embeds: message, username: 'jest-reporter' }
-    this.printResults(summary, 'summary')
-  }
-
-  printResults(data, fileSuffix) {
-    const file = `discord_results-${fileSuffix}.json`
-    console.log('Printing results to', file)
-    data = new Uint8Array(Buffer.from(JSON.stringify(data)))
-    // TODO: Replace with child process curl
-    fs.writeFileSync(file, data)
+    const data = { embeds: message, username: 'jest-reporter' }
+    const out = child_process.execSync(
+      `curl -X POST \
+        -H "Content-Type: application/json" \
+        -d '${JSON.stringify(data)}' \
+        ${process.env.DISCORD_WEBHOOK_URL}
+      `
+    )
+    console.log(out.toString())
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@ceramicnetwork/common": "^0.15.9",
     "@ceramicnetwork/core": "^0.19.7",
     "@ceramicnetwork/http-client": "^0.9.6",
+    "@jest/reporters": "^26.6.2",
     "@types/jest": "^26.0.19",
     "babel-jest": "^26.6.3",
     "dag-jose": "^0.3.0",


### PR DESCRIPTION
### Motivation

We want to manually trigger the tests to run on our infrastructure from GitHub Actions.

### Changes

- Added CI workflow to launch ECS task that runs the tests
- Updated jest-reporter to send discord message when the test run starts and when it completes
<img width="313" alt="image" src="https://user-images.githubusercontent.com/8445610/108911984-fc951c80-75f5-11eb-978b-ae090a2365b5.png">

### Notes
Uses the infra updates already on dev (https://github.com/3box/ceramic-infra/pull/245)