### PR TITLE
fix: print tests passed if not failed tests

### DIFF
--- a/ci/jest-reporter.js
+++ b/ci/jest-reporter.js
@@ -73,7 +73,7 @@ function buildDiscordSummary(results, runId) {
   let title = 'Tests Failed'
   let description = `Run Id: ${runId}`
   let color = 16711712
-  if (results.success) {
+  if (results.numFailedTestSuites < 1) {
     title = 'Tests Passed'
     color = 8781568
   }


### PR DESCRIPTION
Now displays like this in discord
<img width="338" alt="image" src="https://user-images.githubusercontent.com/8445610/112351819-9822b700-8ca0-11eb-8ab3-731dfb28de87.png">
