### PR TITLE
chore(tests): Increase anchor timeout to account for txn timeouts and retries

### DIFF
--- a/src/__tests__/ceramic_cas.ts
+++ b/src/__tests__/ceramic_cas.ts
@@ -9,7 +9,8 @@ declare global {
     const ceramic: CeramicApi
 }
 
-const ANCHOR_TIMEOUT = 60 * 10 // 10 minutes for anchors to happen and be noticed
+// 15 minutes for anchors to happen and be noticed (including potential failures and retries)
+const ANCHOR_TIMEOUT = 60 * 15
 
 describe('Ceramic<->CAS basic integration', () => {
     jest.setTimeout(1000 * 60 * 15) // 15 minutes

--- a/src/__tests__/ceramic_cas.ts
+++ b/src/__tests__/ceramic_cas.ts
@@ -13,7 +13,7 @@ declare global {
 const ANCHOR_TIMEOUT = 60 * 15
 
 describe('Ceramic<->CAS basic integration', () => {
-    jest.setTimeout(1000 * 60 * 15) // 15 minutes
+    jest.setTimeout(1000 * 60 * 30) // 30 minutes
 
     test("basic crud is anchored properly, single update per anchor batch", async () => {
         // Test document creation

--- a/src/__tests__/ceramic_ceramic.ts
+++ b/src/__tests__/ceramic_ceramic.ts
@@ -11,7 +11,8 @@ declare global {
 }
 
 const UPDATE_TIMEOUT = 30     // 30 seconds for regular updates to propagate from one node to another
-const ANCHOR_TIMEOUT = 60 * 10 // 10 minutes for anchors to happen and be noticed
+// 15 minutes for anchors to happen and be noticed (including potential failures and retries)
+const ANCHOR_TIMEOUT = 60 * 15
 
 const createWithOneLoadWithTheOther = async(ceramic1, ceramic2): Promise<void> => {
     const content = { foo: 'bar' }


### PR DESCRIPTION
I've noticed the tests failed once or twice when the CAS anchor eth txn times out multiple times, but ultimately is successful.

Rough math that shows this actually does make sense:
* Anchor happens every 5 minutes
* Each eth txn has a 3 minute timeout, and we get 3 attempts

5 + (3 * 3) = 14 minutes, rounded up to 15 for good measure