### PR TITLE
Increase update timeout to 1 minute

### DIFF
--- a/src/__tests__/ceramic_ceramic.ts
+++ b/src/__tests__/ceramic_ceramic.ts
@@ -11,7 +11,7 @@ declare global {
     const ceramicClient: CeramicApi;
 }
 
-const UPDATE_TIMEOUT = 30     // 30 seconds for regular updates to propagate from one node to another
+const UPDATE_TIMEOUT = 60     // 60 seconds for regular updates to propagate from one node to another
 // 15 minutes for anchors to happen and be noticed (including potential failures and retries)
 const ANCHOR_TIMEOUT = 60 * 15
 


### PR DESCRIPTION
Just on the off chance that the reason it's failing in local_node env is that that env moves slower.  Seems unlikely to be the cause but I just want to rule out that waiting longer would make it work