### PR TITLE
Use IPFS 52 for serviceLauncher

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/submodules/js-ceramic"]
+	path = src/submodules/js-ceramic
+	url = https://github.com/ceramicnetwork/js-ceramic

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "js-ceramic"]
 	path = src/submodules/js-ceramic
 	url = https://github.com/ceramicnetwork/js-ceramic
+	branch = ipfs-52

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "src/submodules/js-ceramic"]
+[submodule "js-ceramic"]
 	path = src/submodules/js-ceramic
 	url = https://github.com/ceramicnetwork/js-ceramic

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache curl
 
 COPY --from=builder node_modules ./node_modules
 
-COPY package*.json jest.config.js babel.config.js tsconfig.json ci/* ./
+COPY package*.json jest.config.js babel.config.js tsconfig.json build_submodules.sh ci/* ./
 COPY config ./config
 COPY src ./src
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ COPY src ./src
 
 RUN npm run build
 
+RUN npm run build:submodules
+
 # NODE_ENV must match desired config file to use for tests
 ENV NODE_ENV="internal-external"
 

--- a/build_submodules.sh
+++ b/build_submodules.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+cd ./src/submodules/js-ceramic
+npm install
+cd ./packages/ipfs-daemon
+npm install
+npm run build

--- a/build_submodules.sh
+++ b/build_submodules.sh
@@ -2,5 +2,4 @@
 cd ./src/submodules/js-ceramic
 npm install
 cd ./packages/ipfs-daemon
-npm install
 npm run build

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/3box/ceramic-integration-tests#readme",
   "scripts": {
     "build": "node_modules/.bin/tsc -p tsconfig.json",
+    "build:submodules": "./build_submodules.sh",
     "launch:services": "node build/serviceLauncher",
     "prebuild": "npm run clean",
     "postinstall": "node-config-ts",

--- a/src/serviceLauncher.ts
+++ b/src/serviceLauncher.ts
@@ -25,13 +25,13 @@ function main() {
         let subprocess = null
 
         if (service.type == 'ipfs') {
-            subprocess = exec(`node node_modules/@ceramicnetwork/ipfs-daemon/bin/ipfs-daemon`,
+            subprocess = exec(`node src/submodules/js-ceramic/packages/ipfs-daemon/bin/ipfs-daemon`,
                 {
                     env: {
                         ...process.env,
                         IPFS_API_PORT: service.port,
                         CERAMIC_NETWORK: 'dev-unstable',
-                        DEBUG: 'bitswap*'
+                        DEBUG: '*error,ipfs:repo,libp2p:connection-manager,libp2p,libp2p:transports,libp2p:tcp*,libp2p:gossipsub*,libp2p:persisten-peer-store,libp2p:peer-store*,libp2p:websockets,libp2p:dialer'
                     }
                 }
             )

--- a/src/serviceLauncher.ts
+++ b/src/serviceLauncher.ts
@@ -31,7 +31,7 @@ function main() {
                         ...process.env,
                         IPFS_API_PORT: service.port,
                         CERAMIC_NETWORK: 'dev-unstable',
-                        DEBUG: '*error,ipfs:repo,libp2p:connection-manager,libp2p,libp2p:transports,libp2p:tcp*,libp2p:gossipsub*,libp2p:persisten-peer-store,libp2p:peer-store*,libp2p:websockets,libp2p:dialer'
+                        DEBUG: '*error,bitswap*,ipfs:repo,libp2p:connection-manager,libp2p,libp2p:transports,libp2p:tcp*,libp2p:gossipsub*,libp2p:persisten-peer-store,libp2p:peer-store*,libp2p:websockets,libp2p:dialer'
                     }
                 }
             )

--- a/src/serviceLauncher.ts
+++ b/src/serviceLauncher.ts
@@ -31,7 +31,7 @@ function main() {
                         ...process.env,
                         IPFS_API_PORT: service.port,
                         CERAMIC_NETWORK: 'dev-unstable',
-                        DEBUG: '*error,bitswap*,ipfs:repo,libp2p:connection-manager,libp2p,libp2p:transports,libp2p:tcp*,libp2p:gossipsub*,libp2p:persisten-peer-store,libp2p:peer-store*,libp2p:websockets,libp2p:dialer'
+                        DEBUG: 'bitswap*'
                     }
                 }
             )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
   ],
   "exclude": [
     "node_modules",
-    "**/__tests__"
+    "**/__tests__",
+    "src/submodules"
   ]
 }


### PR DESCRIPTION
So that the IPFS version we are using in the `local_node-internal` test is compatible with dev infra as of right now