### PR TITLE
fix: increase jest timeout for key revocation

### DIFF
--- a/src/__tests__/key_revocation.ts
+++ b/src/__tests__/key_revocation.ts
@@ -46,8 +46,9 @@ afterEach(() => {
 })
 
 test('key revocation', async () => {
+    jest.setTimeout(1000 * 60 * 30) // 30 minutes
     // 1. Setup initial keys
-    const seedString = `first-seed-${Math.random()}`
+    const seedString = `first-seed-${Math.random()}`;
     const seed = sha256.hash(uint8arrays.fromString(seedString));
     const keyDidResolver = KeyDidResolver.getResolver();
     const threeIdResolver = ThreeIdResolver.getResolver(ceramic);


### PR DESCRIPTION
I'm not positive this will fix *everything* but it is necessary because we wait for anchors and it will allow us to see if any other issues are present.