### PR TITLE
fix: Adjust for tile.update returns Promise<void>

### DIFF
--- a/src/__tests__/key_revocation.ts
+++ b/src/__tests__/key_revocation.ts
@@ -105,5 +105,7 @@ test('key revocation', async () => {
 
     // 5. Current key should work though
     ceramic.did.createJWS = vanillaCreateJWS
-    await expect(tile.update({stage: "Should work"})).resolves.toBeTruthy()
+    const okContent = { stage: 'Should work' }
+    await tile.update(okContent)
+    expect(tile.content).toEqual(okContent)
 })


### PR DESCRIPTION
So, if `tile.update` works, it just passes control over to the current line of code.