### PR TITLE
Use node 14 for Docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.18.0-alpine3.14 as builder
+FROM node:14-alpine as builder
 
 COPY package*.json ./
 
@@ -8,7 +8,7 @@ RUN npm ci --ignore-scripts
 RUN npm rebuild bcrypto
 RUN npm rebuild loady
 
-FROM node:14.18.0-alpine3.14 as app
+FROM node:14-alpine as app
 
 WORKDIR /app
 


### PR DESCRIPTION
### Motivation
- Ceramic is designed for Node 14 so we need to build our test images with that version.

### Changes
- Replace node-alpine with the node 14 version of alpine