### PR TITLE
chore: Temporarily increase integration test timeouts

### DIFF
--- a/src/__tests__/ceramic_cas.ts
+++ b/src/__tests__/ceramic_cas.ts
@@ -11,7 +11,7 @@ declare global {
 }
 
 describe('Ceramic<->CAS basic integration', () => {
-    jest.setTimeout(1000 * 60 * 30) // 30 minutes
+    jest.setTimeout(1000 * 60 * 60) // 1 hour
 
     test("basic crud is anchored properly, single update per anchor batch", async () => {
         // Test document creation

--- a/src/__tests__/ceramic_ceramic.ts
+++ b/src/__tests__/ceramic_ceramic.ts
@@ -81,7 +81,7 @@ const updatesAreShared = async(ceramic1: CeramicApi, ceramic2: CeramicApi, ancho
 }
 
 describe('Ceramic<->Ceramic multi-node integration', () => {
-    jest.setTimeout(1000 * 60 * 30) // 30 minutes
+    jest.setTimeout(1000 * 60 * 60) // 1 hour
 
     test("create with one, load with the other", async () => {
         console.info("Running test 'create with one, load with the other'")

--- a/src/__tests__/key_revocation.ts
+++ b/src/__tests__/key_revocation.ts
@@ -46,7 +46,7 @@ afterEach(() => {
 })
 
 test('key revocation', async () => {
-    jest.setTimeout(1000 * 60 * 30) // 30 minutes
+    jest.setTimeout(1000 * 60 * 60) // 1 hour
     console.log("Starting test: key revocation")
 
     // 1. Setup initial keys

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,7 @@ import { filter, take } from 'rxjs/operators'
 const seed = randomBytes(32)
 
 // 15 minutes for anchors to happen and be noticed (including potential failures and retries)
-export const ANCHOR_TIMEOUT = 60 * 15
+export const ANCHOR_TIMEOUT = 60 * 30
 
 export async function delay(millseconds: number): Promise<void> {
     await new Promise<void>(resolve => setTimeout(() => resolve(), millseconds))


### PR DESCRIPTION
With the restart loop in place for the cas on dev, the time between anchors is longer than normal as we have to wait for ipfs and ceramic to shutdown and restart between every batch.  This is making integration tests fail.  So for now let's increase the test timeouts, and we can set them back once we are using go-ipfs and remove the restart loop.