### PR TITLE
CI for qa env

### DIFF
--- a/.github/workflows/build_and_push_ecr.yml
+++ b/.github/workflows/build_and_push_ecr.yml
@@ -20,7 +20,7 @@ jobs:
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-east-2
+        aws-region: ${{ secrets.AWS_REGION }}
 
     - name: Login to Amazon ECR
       id: login-ecr
@@ -30,7 +30,7 @@ jobs:
       id: build-image
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        ECR_REPOSITORY: ceramic-dev-tests-smoke_tests
+        ECR_REPOSITORY: ceramic-qa-tests-smoke_tests
         SHA_TAG: ${{ github.sha }}
       run: |
         docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$SHA_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .

--- a/.github/workflows/build_and_push_ecr.yml
+++ b/.github/workflows/build_and_push_ecr.yml
@@ -30,7 +30,7 @@ jobs:
       id: build-image
       env:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        ECR_REPOSITORY: ceramic-qa-tests-smoke_tests
+        ECR_REPOSITORY: ceramic-qa-tests-e2e_tests
         SHA_TAG: ${{ github.sha }}
       run: |
         docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$SHA_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -6,7 +6,7 @@ on:
       tests:
         description: "Space separated list of tests to run. Runs all available by default."
         required: false
-        default: 'smoke'
+        default: 'e2e'
 
 name: Run Tests on ECS
 
@@ -17,9 +17,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - smoke_test_config: "private-public"
-          - smoke_test_config: "local_client-public"
-          - smoke_test_config: "local_node-private"
+          - e2e_test_config: "private-public"
+          - e2e_test_config: "local_client-public"
+          - e2e_test_config: "local_node-private"
 
     steps:
     - name: Checkout
@@ -32,13 +32,13 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: ${{ secrets.AWS_REGION }}
 
-    - name: Run smoke tests
-      if: contains('smoke', github.event.inputs.tests)
+    - name: Run integration tests
+      if: contains('e2e', github.event.inputs.tests)
       run: |
         aws ecs run-task \
-          --cluster ceramic-dev-tests \
-          --task-definition ceramic-dev-tests-smoke_tests \
+          --cluster ceramic-qa-tests \
+          --task-definition ceramic-qa-tests-e2e_tests \
           --launch-type FARGATE \
           --network-configuration ${{ secrets.NETWORK_CONFIGURATION }} \
           --enable-execute-command \
-          --overrides '{ "containerOverrides": [{ "name": "smoke_tests", "environment": [{ "name": "NODE_ENV", "value": "${{ matrix.smoke_test_config }}" }, { "name": "AWS_ACCESS_KEY_ID", "value": "${{ secrets.S3_AWS_ACCESS_KEY_ID }}" }, { "name": "AWS_SECRET_ACCESS_KEY", "value": "${{ secrets.S3_AWS_SECRET_ACCESS_KEY }}" }, { "name": "AWS_REGION", "value": "${{ secrets.S3_AWS_REGION }}" }, { "name": "ETH_RPC_URL", "value": "${{ secrets.ETH_RPC_URL }}" }] }] }'
+          --overrides '{ "containerOverrides": [{ "name": "e2e_tests", "environment": [{ "name": "NODE_ENV", "value": "${{ matrix.e2e_test_config }}" }, { "name": "AWS_ACCESS_KEY_ID", "value": "${{ secrets.S3_AWS_ACCESS_KEY_ID }}" }, { "name": "AWS_SECRET_ACCESS_KEY", "value": "${{ secrets.S3_AWS_SECRET_ACCESS_KEY }}" }, { "name": "AWS_REGION", "value": "${{ secrets.S3_AWS_REGION }}" }, { "name": "ETH_RPC_URL", "value": "${{ secrets.ETH_RPC_URL }}" }] }] }'


### PR DESCRIPTION
- deploy to and run on qa infra instead of dev
- use dev-qa ceramic network instead of dev-unstable