### PR TITLE
Must clean state store in teardown not setup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,19 +25,20 @@ export default class IntegrationTestEnvironment extends NodeEnvironment {
             process.exit(1)
         }
 
-        try {
-            // @ts-ignore
-            // clean out old state store for new local node, if this is a local test
-            await this.cleanStateStoreForLocalNode()
-        } catch (e) {
-            console.info("Error on cleaning state store", e.toString())
-            // this may not be fatal, do not die at this point
-        }
     }
 
     async teardown() {
         console.log("Tearing down integration test")
 
+        try {    
+            // clean out state store if this is a local test
+            // @ts-ignore
+            await this.cleanStateStoreForLocalNode()
+        } catch (e) {
+            console.info("Error on cleaning state store", e.toString())
+            // continue teardown even if error 
+        }
+        
         // @ts-ignore
         await this.global.ceramic.close();
         this.global.ceramic = null


### PR DESCRIPTION
We have to clean the state store on teardown, not on setup

because we are using the ceramic node to remove its pins

And the ceramic node will not start if the state store has old data