### PR TITLE
fix: increase wait for commits between cross node indexing queries

### DIFF
--- a/src/__tests__/indexing.ts
+++ b/src/__tests__/indexing.ts
@@ -211,7 +211,7 @@ describe('indexing', () => {
             { anchor: false, publish: false }
           )
 
-          await TestUtils.delay(5 * 1000)
+          await TestUtils.delay(10 * 1000)
 
           // Since ceramic1 didn't publish the commit, ceramic2 won't know about it.
           const resultsAfterCreate = await ceramic2.index
@@ -251,7 +251,7 @@ describe('indexing', () => {
 
           await doc.replace(DATA2, { anchor: false })
 
-          await TestUtils.delay(5 * 1000)
+          await TestUtils.delay(10 * 1000)
 
           const resultsAfterReplace = await ceramic2.index
             .query({ model: TEST_MODEL, last: 100 })
@@ -290,7 +290,7 @@ describe('indexing', () => {
             { anchor: false }
           )
 
-          await TestUtils.delay(5 * 1000)
+          await TestUtils.delay(10 * 1000)
 
           const did1Results = await ceramic2.index
             .query({ model: TEST_MODEL, last: 100, account: did1.id })


### PR DESCRIPTION
Received errors such as this: 
```
  ● indexing › Using existing model › Can filter by DID across nodes -- creating: ceramicClient, loading: ceramic
    expect(received).toBeGreaterThanOrEqual(expected)
    Expected: >= 1
    Received:    0
      308 |             .query({ model: TEST_MODEL, last: 100, account: did2.id })
      309 |             .then(resultObj => extractDocuments(ceramic2, resultObj))
    > 310 |           expect(did2Results.length).toBeGreaterThanOrEqual(1)
          |                                      ^
      311 |
      312 |           const lastDid2Doc = did2Results.at(-1) as ModelInstanceDocument
      313 |           expect(lastDid2Doc.id.toString()).toEqual(doc2.id.toString())
      at toBeGreaterThanOrEqual (src/__tests__/indexing.ts:310:38)
 ```
 
 logs show errors: 
 ```
 [2022-11-15T09:41:19.581Z] ERROR: Error [ReadError]: Database is not open
    at maybeError (/app/node_modules/levelup/lib/levelup.js:325:24)
    at LevelUP.put (/app/node_modules/levelup/lib/levelup.js:208:7)
    at S3StateStore.save (file:///app/node_modules/@ceramicnetwork/cli/src/s3-state-store.ts:84:23)
    at PinStore.add (file:///app/node_modules/@ceramicnetwork/core/src/store/pin-store.ts:55:27)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at Repository.handlePinOpts (file:///app/node_modules/@ceramicnetwork/core/src/state-management/repository.ts:303:7)
    at Repository.load (file:///app/node_modules/@ceramicnetwork/core/src/state-management/repository.ts:238:5)
    at StateManager.handlePubsubUpdate (file:///app/node_modules/@ceramicnetwork/core/src/state-management/state-manager.ts:228:16)
    at Dispatcher._handleUpdateMessage (file:///app/node_modules/@ceramicnetwork/core/src/dispatcher.ts:332:5) {
  [cause]: undefined
}
```

and 
```
[2022-11-13T17:40:26.032Z] ERROR: 'Error while loading commit CID bagcqceraweojzqpmpvusd2xr56afylq64b2cmmfhekcd3m7gm7pef3sqrgqq from IPFS for stream kjzl6kcym7w8y9ap5jp2qkirfjy1lsrxryz8teqj4wy89jf7exprwq6gijzsext: AbortError: The user aborted a request.'
[2022-11-13T17:40:26.033Z] ERROR: 'Error while processing Update message from pubsub: AbortError: The user aborted a request.'
[2022-11-13T17:40:26.113Z] ERROR: AbortError: The user aborted a request.
    at abort (/app/node_modules/ipfs-utils/node_modules/node-fetch/lib/index.js:1418:16)
    at /app/node_modules/ipfs-utils/node_modules/node-fetch/lib/index.js:1428:4
    at new Promise (<anonymous>)
    at fetch (/app/node_modules/ipfs-utils/node_modules/node-fetch/lib/index.js:1407:9)
    at fetch (/app/node_modules/ipfs-utils/src/http/fetch.node.js:20:3)
    at Client.fetch (/app/node_modules/ipfs-utils/src/http.js:133:7)
    at Client.fetch (file:///app/node_modules/ipfs-http-client/esm/src/lib/core.js:132:20)
    at Client.post (/app/node_modules/ipfs-utils/src/http.js:176:17)
    at Object.stat (file:///app/node_modules/ipfs-http-client/esm/src/block/stat.js:6:27)
    at file:///app/node_modules/@ceramicnetwork/core/src/dispatcher.ts:267:31 {
  type: 'aborted'
}
```
which could indicate that ceramic is trying to "index" something but things have shut down already. 
