### PR TITLE
fix: wait for mids to be indexed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "key-did-resolver": "^2.1.3",
         "node-config-ts": "^3.1.0",
         "node-jq": "^2.3.3",
+        "rxjs": "^7.8.0",
         "tmp-promise": "^3.0.3",
         "ts-jest": "^28.0.8",
         "ts-node": "^10.9.1",
@@ -21515,9 +21516,9 @@
       "peer": true
     },
     "node_modules/rxjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
-      "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -42416,9 +42417,9 @@
       }
     },
     "rxjs": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
-      "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
       "requires": {
         "tslib": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "key-did-resolver": "^2.1.3",
     "node-config-ts": "^3.1.0",
     "node-jq": "^2.3.3",
+    "rxjs": "^7.8.0",
     "tmp-promise": "^3.0.3",
     "ts-jest": "^28.0.8",
     "ts-node": "^10.9.1",

--- a/src/__tests__/indexing.ts
+++ b/src/__tests__/indexing.ts
@@ -329,7 +329,8 @@ describe('indexing', () => {
           expect(did1Results.length).toBeGreaterThanOrEqual(1)
 
           // We cannot expect that the most recent MID will be the MID created by this test
-          // This is because we may receive and process pubsub messages for docs created by ceramicClient
+          // This is because we may receive and process pubsub messages for docs created in previous tests
+          // ex. docs created by the ceramicClient in the previous test, may be received by ceramic in this test
           const retrievedDid1Doc = did1Results.find(
             doc => doc.id.toString() === doc1.id.toString()
           ) as ModelInstanceDocument

--- a/src/__tests__/indexing.ts
+++ b/src/__tests__/indexing.ts
@@ -178,6 +178,8 @@ describe('indexing', () => {
             .then(resultObj => extractDocuments(ceramicInstance, resultObj))
 
           expect(did1Results.length).toBeGreaterThanOrEqual(1)
+          // We cannot expect that the most recent MID will be the MID created by this test
+          // This is because we may receive and process pubsub messages for docs created by ceramicClient
           const retrievedDoc1 = did1Results.find(
             doc => doc.id.toString() === doc1.id.toString()
           ) as ModelInstanceDocument
@@ -297,7 +299,7 @@ describe('indexing', () => {
           expect(did1Results.length).toBeGreaterThanOrEqual(1)
 
           // We cannot expect that the most recent MID will be the MID created by this test
-          // This is because we receive and process pubsub messages for docs created by at inconsistent times
+          // This is because we may receive and process pubsub messages for docs created by ceramicClient
           const retrievedDid1Doc = did1Results.find(
             doc => doc.id.toString() === doc1.id.toString()
           ) as ModelInstanceDocument


### PR DESCRIPTION
fixes two things:
- we cannot control the order we receive pubsub messages. We cannot expect the most recently indexed mid to be the one we created
- sometimes it takes a while to receive mids created by a remote node. We attempted to use a delay but sometimes it is not enough. So i am using a polling strategy