### PR TITLE
fix: update s3 call with the new API

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -199,7 +199,7 @@ export async function buildCeramic(configObj, ipfs?: IpfsApi): Promise<CeramicAp
     ceramic.did = did
     if (configObj.s3StateStoreBucketName) {
       const bucketName = `${configObj.s3StateStoreBucketName}${S3_DIRECTORY_NAME}`
-      const s3Store = new S3Store(bucketName, null, configObj.network)
+      const s3Store = new S3Store(configObj.network, bucketName)
       await ceramic.repository.injectKeyValueStore(s3Store)
     }
 


### PR DESCRIPTION

## Description
The call to initialize s3 needed to be updated to a new parameter order based on the dependency upgrade. 

## How Has This Been Tested?

Running the tests locally produced an error about `null.dev-unstable` after making this change the error was resolved.

## Definition of Done

Before submitting this PR, please make sure:

- [ ] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [ ] My code follows conventions, is well commented, and easy to understand
- [ ] My code builds and tests pass without any errors or warnings
- [ ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
