### PR TITLE
fix: use new pin api under admin namespace

### DIFF
--- a/src/__tests__/ceramic_state_store.ts
+++ b/src/__tests__/ceramic_state_store.ts
@@ -14,7 +14,7 @@ declare global {
 }
 
 const isPinned = async (ceramic: CeramicApi, streamId: StreamID): Promise<boolean> => {
-  const pinnedStreamsIterator = await ceramic.pin.ls(streamId)
+  const pinnedStreamsIterator = await ceramic.admin.pin.ls(streamId)
   const pinnedStreamIds = []
   for await (const id of pinnedStreamsIterator) {
     pinnedStreamIds.push(id)
@@ -85,7 +85,7 @@ describe('Ceramic state store tests', () => {
     expect(loaded.content).toEqual(newContent)
 
     expect(await isPinned(ceramic, doc.id)).toBeTruthy()
-    await ceramic.pin.rm(doc.id)
+    await ceramic.admin.pin.rm(doc.id)
     expect(await isPinned(ceramic, doc.id)).toBeFalsy()
   })
 })


### PR DESCRIPTION

## Description

Update test code to use new API of `ceramic.admin.pin.*` instead of `ceramic.pin.*`. 

## How Has This Been Tested?

Locally ran tests

## Definition of Done

Before submitting this PR, please make sure:

- [ ] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [ ] My code follows conventions, is well commented, and easy to understand
- [ ] My code builds and tests pass without any errors or warnings
- [ ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
