### PR TITLE
fix: use unique s3 bucket path for each test

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -198,8 +198,10 @@ export async function buildCeramic(configObj, ipfs?: IpfsApi): Promise<CeramicAp
     const did = await createDid(seed)
     ceramic.did = did
     if (configObj.s3StateStoreBucketName) {
-      const bucketName = `${configObj.s3StateStoreBucketName}${S3_DIRECTORY_NAME}`
-      const s3Store = new S3Store(configObj.network, bucketName)
+      // Use a unique bucket path for each test
+      const now = new Date().getUTCMilliseconds()
+      const bucketNameWithPath = `${configObj.s3StateStoreBucketName}${S3_DIRECTORY_NAME}/${now}`
+      const s3Store = new S3Store(configObj.network, bucketNameWithPath)
       await ceramic.repository.injectKeyValueStore(s3Store)
     }
 


### PR DESCRIPTION
## Description

Running tests locally without this change breaks since the old s3 data was still around. Specifically the `local_node-private` mode test would fail since the existing s3 bucket would have information about streams from previous runs. When the node starts up it would try and find those streams in IPFS but they would not exist and the node would fail to start.

## How Has This Been Tested?

Running tests locally.
