### PR TITLE
fix: add explicit dependency on kubo-rpc-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "jest-resolver-enhanced": "^1.0.1",
         "key-did-provider-ed25519": "^2.0.1",
         "key-did-resolver": "^3.0.0",
+        "kubo-rpc-client": "^3.0.1",
         "node-config-ts": "^3.1.0",
         "node-jq": "^2.3.3",
         "rxjs": "^7.8.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "jest-resolver-enhanced": "^1.0.1",
     "key-did-provider-ed25519": "^2.0.1",
     "key-did-resolver": "^3.0.0",
+    "kubo-rpc-client": "^3.0.1",
     "node-config-ts": "^3.1.0",
     "node-jq": "^2.3.3",
     "rxjs": "^7.8.0",


### PR DESCRIPTION

## Description

We needed to name the kubo-rpc-client dependency version explicitly to talk to Kubo 18 successfully.

## How Has This Been Tested?

Ran tests locally

## Definition of Done

Before submitting this PR, please make sure:

- [ ] The work addresses the description and outcomes in the issue
- [ ] I have added relevant tests for new or updated functionality
- [ ] My code follows conventions, is well commented, and easy to understand
- [ ] My code builds and tests pass without any errors or warnings
- [ ] I have tagged the relevant reviewers
- [ ] I have updated the READMEs of affected packages
- [ ] I have made corresponding changes to the documentation
- [ ] The changes have been communicated to interested parties

## References:

Please list relevant documentation (e.g. tech specs, articles, related work etc.) relevant to this change, and note if the documentation has been updated.
